### PR TITLE
icon: Update icon size

### DIFF
--- a/src/components/02-elements/icon/icon.scss
+++ b/src/components/02-elements/icon/icon.scss
@@ -2,7 +2,7 @@
   --icon-color: var(--color-teal);
 
   display: inline-block;
-  $icon-size: 16px;
+  $icon-size: 24px;
 
   &__overlaid-text {
     font-size: $icon-size / 2;


### PR DESCRIPTION
The icon size in the design system is being set by the material icons css not the provided scss. This resolves that issues in cases where the latter has higher specificity or priority