### PR TITLE
src: project-styles: insights: custom: flex grid print

### DIFF
--- a/src/project-styles/insights/custom.scss
+++ b/src/project-styles/insights/custom.scss
@@ -138,10 +138,14 @@ ul.dataset-select>li {
         page-break-inside: avoid;
     }
     input {
-        display: none
+        display: none;
     }
     .bar-chart {
         overflow: hidden;
+    }
+    .print-grid {
+        display: flex;
+        flex-direction: row;
     }
 }
 


### PR DESCRIPTION
Chrome:
- Summary box in one line.
- Funders on page 1.
- Summary box and funders vertical line do not align.

<img width="429" alt="Screen Shot 2022-02-03 at 14 46 26" src="https://user-images.githubusercontent.com/9610927/152366045-72aa8e5b-3263-473a-9725-d0eecd353563.png">

Firefox:
- Summary box was already in one line and it is still the same.
- Funders page still on page 2.