### PR TITLE
src: project-styles: insights: custom: add underline-text

### DIFF
--- a/src/project-styles/insights/custom.scss
+++ b/src/project-styles/insights/custom.scss
@@ -133,6 +133,11 @@ ul.dataset-select>li {
     margin: 0;
 }
 
+.underline-text a {
+  text-decoration: underline;
+  text-underline-position: under;
+}
+
 @media print {
     .base-card {
         page-break-inside: avoid;


### PR DESCRIPTION
Making links more visible. Relates to https://github.com/ThreeSixtyGiving/insights-ng/issues/70 

If we use what we have in the `design system` it would increase the font and move the paragraph to the right.

<img width="1074" alt="Screen Shot 2022-02-14 at 10 39 16" src="https://user-images.githubusercontent.com/9610927/153848652-e4e73641-989a-4bb6-882b-f9dd398dc664.png">

Or

<img width="1061" alt="Screen Shot 2022-02-14 at 10 38 50" src="https://user-images.githubusercontent.com/9610927/153848663-7d824909-e3c8-4d24-a551-cdca6fb4739a.png">

I propose keep the font as we have it now and to add a custom underline:

<img width="1011" alt="Screen Shot 2022-02-14 at 10 28 54" src="https://user-images.githubusercontent.com/9610927/153848063-8ee31dbe-c95b-4827-bf84-294da11ae6fe.png">
