### PR TITLE
components: cookie-consent: fix padding and position

### DIFF
--- a/src/components/02-elements/cookie-consent/cookie-consent.scss
+++ b/src/components/02-elements/cookie-consent/cookie-consent.scss
@@ -1,7 +1,10 @@
 .cookie-consent {
+  padding-top: 0 !important;
   width: 450px;
   height: 325px;
-  position: fixed;
+  position: fixed !important;
   bottom: 0;
   left: 0;
+  background: #f9e1d3 !important;
+  z-index: 99;
 }


### PR DESCRIPTION
This PR fixes the text being outside the box and the position.

The box is transparent and it is difficult to read the text. Is that okay?

<img width="499" alt="Screen Shot 2022-03-18 at 15 21 08" src="https://user-images.githubusercontent.com/9610927/159031420-4e3bdb65-f5d8-4ffd-a886-73ae083b8143.png">
