### PR TITLE
cookies-consent: Avoid cookie consent box flicker

### DIFF
--- a/src/components/02-elements/cookie-consent/cookie-consent.njk
+++ b/src/components/02-elements/cookie-consent/cookie-consent.njk
@@ -22,8 +22,12 @@
     <!-- End Matomo Code -->
 
     <script type="text/javascript">
-        function hideCookieConsentDialog(){
-          document.getElementsByClassName("cookie-consent")[0].style.display = 'none';
+        function hideCookieConsentDialog(hide){
+          if (hide){
+            document.getElementsByClassName("cookie-consent")[0].style.display = 'none';
+          } else {
+            document.getElementsByClassName("cookie-consent")[0].style.display = 'block';
+          }
         }
 
         function noCookieConsent() {
@@ -34,7 +38,9 @@
           if (document.cookie.indexOf("mtm_cookie_consent") > -1 ||
               document.cookie.indexOf("mtm_consent_removed") > -1 ||
               document.cookie.indexOf("noEnhancedAnalytics") > -1) {
-             hideCookieConsentDialog();
+            hideCookieConsentDialog(true);
+          } else {
+            hideCookieConsentDialog(false);
           }
         });
     </script>
@@ -48,9 +54,9 @@
             <a class="base-card__text" href="https://www.threesixtygiving.org/privacy/"> More Information &amp; Privacy Policy</a>
           </h2>
           <p class="base-card__text">
-              <a href="#" onclick="_paq.push(['rememberCookieConsentGiven']); hideCookieConsentDialog();" class="button">Yes</a>
-              <a href="#" onclick="noCookieConsent(); hideCookieConsentDialog();" class="button">No</a>
-              <a href="#" onclick="_paq.push(['optUserOut']); hideCookieConsentDialog();" class="button">Disable Analytics</a>
+              <a href="#" onclick="_paq.push(['rememberCookieConsentGiven']); hideCookieConsentDialog(true);" class="button">Yes</a>
+              <a href="#" onclick="noCookieConsent(); hideCookieConsentDialog(true);" class="button">No</a>
+              <a href="#" onclick="_paq.push(['optUserOut']); hideCookieConsentDialog(true);" class="button">Disable Analytics</a>
           </p>
           <p id="cookie-dialog-desc" style="font-style: italic;">360Giving uses privacy-respecting analytics. If you don't accept cookies, we will track only basic information about your visit. Click "Disable Analytics" if you don't want us to track at all. </p>
       </div>

--- a/src/components/02-elements/cookie-consent/cookie-consent.scss
+++ b/src/components/02-elements/cookie-consent/cookie-consent.scss
@@ -1,4 +1,5 @@
 .cookie-consent {
+  display: none;
   padding-top: 0 !important;
   width: 450px;
   height: 325px;


### PR DESCRIPTION
Start with the cookie-consent box hidden until we know the consent
status. This stops the cookie consent box being shown and then hidden
straight away causing a slight flicker.