### PR TITLE
cookie-consent: Stop the base-card class overriding display property

### DIFF
--- a/src/components/02-elements/cookie-consent/cookie-consent.njk
+++ b/src/components/02-elements/cookie-consent/cookie-consent.njk
@@ -24,9 +24,9 @@
     <script type="text/javascript">
         function hideCookieConsentDialog(hide){
           if (hide){
-            document.getElementsByClassName("cookie-consent")[0].style.display = 'none';
+            document.getElementsByClassName("cookie-consent")[0].style.setProperty("display", "none", "important");
           } else {
-            document.getElementsByClassName("cookie-consent")[0].style.display = 'block';
+            document.getElementsByClassName("cookie-consent")[0].style.setProperty("display", "block", "important");
           }
         }
 

--- a/src/components/02-elements/cookie-consent/cookie-consent.scss
+++ b/src/components/02-elements/cookie-consent/cookie-consent.scss
@@ -1,5 +1,5 @@
 .cookie-consent {
-  display: none;
+  display: none !important;
   padding-top: 0 !important;
   width: 450px;
   height: 325px;


### PR DESCRIPTION
Depending on the ordering of the css loading the display property for
base-card overrides the display: none/block toggle. Use "!important" to
override this.

https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty