### PR TITLE
Underlining links

### DIFF
--- a/src/components/02-elements/typography/typography.scss
+++ b/src/components/02-elements/typography/typography.scss
@@ -173,5 +173,10 @@ p {
   }
 }
 
+p > a {
+  text-decoration: underline;
+}
 
-
+ul > li > a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
related to #59 

`underline` has been added in paragraphs and lists.

<img width="941" alt="Screen Shot 2022-05-25 at 14 32 10" src="https://user-images.githubusercontent.com/9610927/170460064-ffc2caee-3e68-4ba7-bd44-c8bcda80ebd6.png">

