### PR TITLE
anchors: Globally set `text-decoration: underline;`

### DIFF
--- a/src/components/02-elements/anchors/anchors.scss
+++ b/src/components/02-elements/anchors/anchors.scss
@@ -1,6 +1,8 @@
 a {
   font-weight: 400;
   color: hsla(var(--teal-dark-hsl), 1);
+  text-decoration: underline;
+  text-underline-position: under;
 
   &:hover { color: hsla(var(--orange-dark-hsl), 1);; }
   &:active { color: hsla(var(--yellow-dark-hsl), 1);; }

--- a/src/components/02-elements/page-title/page-title.scss
+++ b/src/components/02-elements/page-title/page-title.scss
@@ -12,7 +12,6 @@
     a {
       font-size: 24px;
       font-weight: 400;
-      text-decoration: underline;
     }
   }
 }

--- a/src/components/02-elements/typography/typography.scss
+++ b/src/components/02-elements/typography/typography.scss
@@ -159,7 +159,6 @@ p {
   font-weight: 400;
   color: hsla(var(--base-hsl), 1);
   margin-bottom: 0;
-  // & + & { margin-top: 1rem; }
 
   @include breakpoint($large) { font-size: 1.2rem; }
 }
@@ -171,12 +170,4 @@ p {
     font-weight: 400;
     color: var(--color-teal-dark);
   }
-}
-
-p > a {
-  text-decoration: underline;
-}
-
-ul > li > a {
-  text-decoration: underline;
 }

--- a/src/components/04-modules/footer/footer.scss
+++ b/src/components/04-modules/footer/footer.scss
@@ -24,8 +24,6 @@
   ul { 
     list-style-type: none; 
     padding: 0;
-
-    a { text-decoration: none; }
   }
 
   a {

--- a/src/components/04-modules/prose/prose.scss
+++ b/src/components/04-modules/prose/prose.scss
@@ -24,8 +24,6 @@
 .prose a {
   font-weight: inherit;
   color: hsla(var(--teal-dark-hsl), 1);
-  text-decoration: underline;
-  text-underline-position: under;
 
   &:hover {
     background-color: hsl(var(--teal-hsl), 0.1);

--- a/src/components/04-modules/top-bar/top-bar.scss
+++ b/src/components/04-modules/top-bar/top-bar.scss
@@ -3,7 +3,6 @@
   // Resetting styles
   ul { padding: 0; margin: 0;}
   li { list-style: none; margin: 0; }
-  a { text-decoration: none; }
 }
 
 // Component Styles Variables

--- a/src/scss/pre/_reset.scss
+++ b/src/scss/pre/_reset.scss
@@ -130,17 +130,14 @@ sup {
 
 a {
   color: var(--color-accent);
-  text-decoration: none;
   -webkit-text-decoration-skip: objects;
 
   &:hover, &:focus {
     color: var(--color-accent);
-    text-decoration: none;
   }
 
   &:active {
     color: var(--color-orange);
-    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
## Summary
Remove global setting of links to `text-decoration: none;` and re-apply `text-decoration: underline;`. Also remove various workarounds which applied exceptions to the old rule.

https://github.com/ThreeSixtyGiving/360-ds/issues/59

## Verify
Check any link within the design system. There are a few exceptions, such as links without `href` or those omitted from the `tabindex`, and a few edge-cases such as focussed screen-reader-specific links, but these should be rare.