### PR TITLE
search: Fix search / table responsivity

### DIFF
--- a/src/components/06-prototypes/grant-nav/grant-nav.scss
+++ b/src/components/06-prototypes/grant-nav/grant-nav.scss
@@ -50,6 +50,7 @@
   }
 
   &__content {
+    overflow-x: auto;
     padding-top: 0px;
     width: 100%;
 


### PR DESCRIPTION
## Summary
Add `overflow-x` CSS property to the `.search__content` to ensure it handles responsive behaviour properly.

Fixes part of https://github.com/ThreeSixtyGiving/grantnav/issues/918