### PR TITLE
components: bar-chart: Update how charts display values

### DIFF
--- a/src/components/03-components/bar-chart/bar-chart.njk
+++ b/src/components/03-components/bar-chart/bar-chart.njk
@@ -1,8 +1,8 @@
 <ul class="bar-chart">
   {% for item in chart %}
-  <li class="bar-chart__item" style="--value: {{ item.value }}; --width: {{ item.width }};">
+  <li class="bar-chart__item"  style="--width: {{ item.width }};">
     <div class="bar-chart__label">{{ item.label }}</div>
-    <div class="bar-chart__bar"><span></span></div>
+    <div class="bar-chart__bar"><span data-val="{{ item.value }}"></span></div>
   </li>
   {% endfor %}
 </ul>

--- a/src/components/03-components/bar-chart/bar-chart.scss
+++ b/src/components/03-components/bar-chart/bar-chart.scss
@@ -6,7 +6,6 @@
   --bar-bg-color: hsla(var(--yellow-hsl), 1);
 
   &__item {
-    --value: 0;
     display: flex;
     padding-bottom: 8px;
   }
@@ -27,8 +26,7 @@
     }
 
     > span:after {
-      counter-reset: value var(--value);
-      content: counter(value);
+      content: attr(data-val);
       position: absolute;
       left: calc(100% + 8px);
     }

--- a/src/components/04-modules/chart-card/chart-card.njk
+++ b/src/components/04-modules/chart-card/chart-card.njk
@@ -8,9 +8,9 @@
 
     <ul class="bar-chart">
       {% for i in chart %}
-      <li class="bar-chart__item" style="--value: {{ i.value }}; --width: {{ i.width }};">
+      <li class="bar-chart__item" style="--width: {{ i.width }};">
         <div class="bar-chart__label">£2,001 - £5,000</div>
-        <div class="bar-chart__bar"><span></span></div>
+        <div class="bar-chart__bar"><span data-val="{{ i.value }}"></span></div>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
+ Remove `--value` and CSS counter
+ Add `data-val` data attribute to allow string values to be displayed

**NOTE:** This BREAKING CHANGE alters how values are passed into bar charts to display values as labels.

Previous structure:
```njk
<li class="bar-chart__item"  style="--value: {{ item.value }} --width: {{ item.width }};">
    <div class="bar-chart__label">{{ item.label }}</div>
    <div class="bar-chart__bar"><span></span></div>
  </li>
```

New structure:
```njk
<li class="bar-chart__item"  style="--width: {{ item.width }};">
    <div class="bar-chart__label">{{ item.label }}</div>
    <div class="bar-chart__bar"><span data-val="{{ item.value }}"></span></div>
  </li>
```

Prerequisite to: https://github.com/ThreeSixtyGiving/360insights/pull/165
Fixes: https://github.com/ThreeSixtyGiving/360insights/issues/55