### PR TITLE
ml/non-interactive charts

### DIFF
--- a/src/project-styles/insights/custom.scss
+++ b/src/project-styles/insights/custom.scss
@@ -110,7 +110,8 @@ ul.dataset-select>li {
    overflow-x: hidden;
 }
 
-.bar-chart:not(.non-interactive) li, label {
+.bar-chart:not(.non-interactive) li,
+.bar-chart:not(.non-interactive) label {
     cursor: pointer;
 }
 

--- a/src/project-styles/insights/custom.scss
+++ b/src/project-styles/insights/custom.scss
@@ -69,7 +69,7 @@ ul.dataset-select>li {
 .base-card--yellow .bar-chart__bar>span {
     background-color: var(--color-yellow);
 }
-.base-card--yellow .bar-chart__bar > span:hover {
+.base-card--yellow .bar-chart:not(.non-interactive) .bar-chart__bar > span:hover {
     background-color: var(--color-yellow-dark);
 }
 
@@ -77,7 +77,7 @@ ul.dataset-select>li {
     background-color: var(--color-red);
     opacity: 0.9;
 }
-.base-card--red .bar-chart__bar:hover > span {
+.base-card--red .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
     background-color: var(--color-red);
     opacity: 1;
 }
@@ -85,14 +85,14 @@ ul.dataset-select>li {
 .base-card--teal .bar-chart__bar>span {
     background-color: var(--color-teal);
 }
-.base-card--teal .bar-chart__bar:hover > span {
+.base-card--teal .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
     background-color: var(--color-teal-dark);
 }
 
 .base-card--orange .bar-chart__bar>span {
     background-color: var(--color-orange);
 }
-.base-card--orange .bar-chart__bar:hover > span {
+.base-card--orange .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
     background-color: var(--color-orange-dark);
 }
 
@@ -110,11 +110,11 @@ ul.dataset-select>li {
    overflow-x: hidden;
 }
 
-.bar-chart li, label {
+.bar-chart:not(.non-interactive) li, label {
     cursor: pointer;
 }
 
-.bar-chart label:hover {
+.bar-chart:not(.non-interactive) label:hover {
     color: var(--color-orange-dark);
 }
 


### PR DESCRIPTION
Summary
Add `:not(.non-interactive)` condition to bar chart interaction styles

Fixes https://github.com/ThreeSixtyGiving/360insights/issues/174

## Verify
1. Add `.non-interactive` class to a `ul.bar-chart`
2. Bar spans and labels will no longer show interactive elements (colour will not change on `:hover`, cursor will not change to `pointer`)