### PR TITLE
components: Change media-card__content_no_image width units

### DIFF
--- a/src/components/04-modules/media-card/media-card.scss
+++ b/src/components/04-modules/media-card/media-card.scss
@@ -80,7 +80,7 @@
   &__content_no_image { 
     justify-content: center;
     padding: 20px;
-    width: 100%;
+    width: 100vw;
   }
    
   &__image-wrapper {


### PR DESCRIPTION
## Summary
+ Change width units to viewport width `vw`

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/913