### PR TITLE
filter-wrapper: Prevent pointer events on larger screens

### DIFF
--- a/src/components/05-templates/filter-wrapper/filter-wrapper.scss
+++ b/src/components/05-templates/filter-wrapper/filter-wrapper.scss
@@ -25,6 +25,7 @@
       background: none;
       padding-left: 0;
       margin-bottom: 6px;
+      pointer-events: none;
     }
 
     &:focus {


### PR DESCRIPTION
Prevents details summary toggle functionality on larger screens (see https://github.com/ThreeSixtyGiving/grantnav/issues/1163).